### PR TITLE
Remember causes of partial matches

### DIFF
--- a/crltool/crltool/__main__.py
+++ b/crltool/crltool/__main__.py
@@ -116,6 +116,8 @@ def create_argument_parser() -> argparse.ArgumentParser:
     subparser_prove.add_argument('--depth', type=int, default=10)
     subparser_prove.add_argument('--from-json', action='store_true', default=False)
     subparser_prove.add_argument('--trusted-claim-blacklist', type=str, default="")
+    subparser_prove.add_argument('--cut-on-branch', action='store_true', default=False)
+    subparser_prove.add_argument('--filter-candidate-matches', action='store_true', default=False)
 
     subparser_load_frontend_spec = subparsers.add_parser('load-frontend-spec', help='Load a frontend-generated specification')
     subparser_load_frontend_spec.add_argument('--specification', required=True)
@@ -380,6 +382,8 @@ def prove(rs: ReachabilitySystem, args) -> int:
         check_eclp_impl_valid=eclp_impl_valid_trough_lists,
         max_depth=int(args['depth']),
         goal_as_cutpoint=True,
+        cut_on_branch=bool(args['cut_on_branch']),
+        filter_candidate_matches=bool(args['filter_candidate_matches']),
     )
     for claim_name,claim in spec.claims.items():
         _LOGGER.info(f"Going to verify claim {claim_name}")

--- a/crltool/crltool/__main__.py
+++ b/crltool/crltool/__main__.py
@@ -116,8 +116,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
     subparser_prove.add_argument('--depth', type=int, default=10)
     subparser_prove.add_argument('--from-json', action='store_true', default=False)
     subparser_prove.add_argument('--trusted-claim-blacklist', type=str, default="")
-    subparser_prove.add_argument('--cut-on-branch', action='store_true', default=False)
-    subparser_prove.add_argument('--filter-candidate-matches', action='store_true', default=False)
+    subparser_prove.add_argument('--dont-filter-candidate-matches', action='store_true', default=False)
 
     subparser_load_frontend_spec = subparsers.add_parser('load-frontend-spec', help='Load a frontend-generated specification')
     subparser_load_frontend_spec.add_argument('--specification', required=True)
@@ -382,8 +381,7 @@ def prove(rs: ReachabilitySystem, args) -> int:
         check_eclp_impl_valid=eclp_impl_valid_trough_lists,
         max_depth=int(args['depth']),
         goal_as_cutpoint=True,
-        cut_on_branch=bool(args['cut_on_branch']),
-        filter_candidate_matches=bool(args['filter_candidate_matches']),
+        filter_candidate_matches=not bool(args['dont_filter_candidate_matches']),
     )
     for claim_name,claim in spec.claims.items():
         _LOGGER.info(f"Going to verify claim {claim_name}")

--- a/crltool/crltool/verify.py
+++ b/crltool/crltool/verify.py
@@ -790,7 +790,7 @@ class Verifier:
         ).valid
     
     def transform_goals(self, goals: List[VerifyGoal]) -> Optional[List[VerifyGoal]]:
-        new_goals : List[VerifyGoal]
+        new_goals : List[VerifyGoal] = []
         for goal in goals:
             if len(combine_candidate_matches(goal.candidate_matches)) >= 1:
                 new_goals.append(goal)

--- a/crltool/crltool/verify.py
+++ b/crltool/crltool/verify.py
@@ -792,11 +792,15 @@ class Verifier:
     def transform_goals(self, goals: List[VerifyGoal]) -> Optional[List[VerifyGoal]]:
         new_goals : List[VerifyGoal] = []
         for goal in goals:
+            # If the matches on individual components share a source, the goal might be provable.
             if len(combine_candidate_matches(goal.candidate_matches)) >= 1:
                 new_goals.append(goal)
                 continue
+            # If they do not share a source, the goal is provable only if the antecedent is contradictory.
             if self.is_contradiction(goal.antecedent):
                 continue
+            # So if the antecedent is NOT contradictory, the goal is unprovable, and the whole contradiction
+            # is not worth trying.
             return None
         return new_goals
 

--- a/crltool/crltool/verify.py
+++ b/crltool/crltool/verify.py
@@ -250,8 +250,7 @@ CandidateType = Enum('CandidateType', [
     'Axiom',
     'CandidateCircularity',
     'FlushedCircularity',
-    'Stuck',
-    'Branching'])
+    ])
 Candidate = Tuple[CandidateType, str]
 
 @final
@@ -260,7 +259,6 @@ class VerifySettings:
     check_eclp_impl_valid : Callable[[ReachabilitySystem, ECLP, ECLP], EclpImpliesResult]
     goal_as_cutpoint : bool
     max_depth : int
-    cut_on_branch : bool
     filter_candidate_matches : bool
 
 @dataclass
@@ -1063,7 +1061,6 @@ class Verifier:
         flushed_cutpoints : Dict[str, ECLP],
         user_cutpoint_blacklist : List[str],
         progress_from_initial : bool,
-        branching : bool = False,
     ) -> Iterable[ExeCut]:
         _LOGGER.info(f"advance_to_limit a pattern in depth {depth}, in direction {j}")
 
@@ -1077,8 +1074,6 @@ class Verifier:
             ),
             user_cutpoint_blacklist=user_cutpoint_blacklist
         )
-        if branching and self.settings.cut_on_branch:
-            matches00.append((CandidateType.Branching, ""))
 
         if len(matches00) >= 1 or (depth >= self.settings.max_depth):
             if len(matches00) < 1 and (depth >= self.settings.max_depth):
@@ -1105,7 +1100,6 @@ class Verifier:
                         flushed_cutpoints=flushed_cutpoints,
                         progress_from_initial=progress_from_initial,
                         user_cutpoint_blacklist=user_cutpoint_blacklist,
-                        branching=True,
                     ))
                 yield from self.combine_exe_cuts_0(its)
                 #combined0 = self.combine_exe_cuts_0(its)
@@ -1156,7 +1150,7 @@ class Verifier:
             phi=phi,
             depth=depth,
             stuck=True,
-            matches=matches00.copy(), #[(CandidateType.Stuck, "")],
+            matches=matches00.copy(),
             progress_from_initial=progress_from_initial
         )
         if len(matches00) >= 1:

--- a/crltool/crltool/verify.py
+++ b/crltool/crltool/verify.py
@@ -536,7 +536,7 @@ class StackGoalConjunctionChooserStrategy(GoalConjunctionChooserStrategy):
         l = [GoalConjunction(goals=list(gc.goals), can_make_steps=gc.can_make_steps)  for gc in gcs]
         # We can do len(list(...)) only because it actually is a list, see the line above
         _LOGGER.info(f"Inserting goal conjunctions: {[(len(list(x.goals)), x.can_make_steps) for x in l]}")
-        pprint.pprint([[g.candidate_matches for g in x.goals] for x in l])
+        #pprint.pprint([[g.candidate_matches for g in x.goals] for x in l])
         self._stack.extend(l)
         return
 
@@ -645,7 +645,7 @@ class Verifier:
         ]
         if all([apgr.proved for _,apgr in apgresults]):
             _LOGGER.info(f"All goals ({len(apgresults)}) of the conjunction were proved")
-            pprint.pprint({ g.goal_id : g.candidate_matches for g in conj.goals})
+            #pprint.pprint({ g.goal_id : g.candidate_matches for g in conj.goals})
             return True
         
         if not conj.can_make_steps:
@@ -985,7 +985,7 @@ class Verifier:
             phi = reduce(lambda p, var: Exists(self.rs.top_sort, var, p), eclp.vars, eclp.clp.lp.patterns[j])
             
             if self.implies_small(pattern_j, phi):
-                _LOGGER.debug(f"Implies {self.rs.kprint.kore_to_pretty(phi)}")
+                #_LOGGER.debug(f"Implies {self.rs.kprint.kore_to_pretty(phi)}")
                 usable.append(candidate)
             
         for name, eclp in self.trusted_axioms.items():


### PR DESCRIPTION
When exploring an execution tree, remember which axioms/circularities/conclusion(s) were matched - I call these 'Candidates'.
Then, consider only those combinations of components that share a common Candidate.
This is supposed to be an optimization; maybe it is premature, but I already have it debugged, so I am going to merge this.